### PR TITLE
Disable effect when window gets maximized

### DIFF
--- a/shapecorners.h
+++ b/shapecorners.h
@@ -43,6 +43,7 @@ public:
     void reconfigure(ReconfigureFlags flags);
     void prePaintWindow(KWin::EffectWindow* w, KWin::WindowPrePaintData& data, int time);
     void paintWindow(KWin::EffectWindow* w, int mask, QRegion region, KWin::WindowPaintData& data);
+    void windowMaximizedStateChanged(KWin::EffectWindow *w, bool horizontal, bool vertical);
     virtual int requestedEffectChainPosition() const { return 100; }
 
 private:
@@ -52,6 +53,7 @@ private:
     int m_size, m_rSize, m_alpha;
     QSize m_corner;
     QRegion m_updateRegion;
+    KWin::EffectWindow *applyEffect;
     KWin::GLShader *m_shader;
 };
 


### PR DESCRIPTION
Works fine. I chose to use the entire KWin::EffectWindow object over just the class since I only wanted to apply the effect to the window being maximized. It looked really strange when you maximized a window and suddenly all windows with that class lost their rounded borders. I couldn't find a way to get the window id from the object. If there is obviously that should be used instead. Solves #7 (at least the maximize part).